### PR TITLE
Fix vyos terminal length issue

### DIFF
--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -41,10 +41,13 @@ class TerminalModule(TerminalBase):
     ]
 
     try:
-        terminal_length = os.getenv('ANSIBLE_VYOS_TERMINAL_LENGTH', 10000)
+        terminal_length = os.getenv("ANSIBLE_VYOS_TERMINAL_LENGTH", 10000)
         terminal_length = int(terminal_length)
     except ValueError:
-        raise AnsibleConnectionFailure("Invalid value set for vyos terminal length '%s', value should be a valid integer string" % terminal_length)
+        raise AnsibleConnectionFailure(
+            "Invalid value set for vyos terminal length '%s', value should be a valid integer string"
+            % terminal_length
+        )
 
     def on_open_shell(self):
         try:

--- a/plugins/terminal/vyos.py
+++ b/plugins/terminal/vyos.py
@@ -40,7 +40,11 @@ class TerminalModule(TerminalBase):
         re.compile(br"\n\s+Set failed"),
     ]
 
-    terminal_length = os.getenv("ANSIBLE_VYOS_TERMINAL_LENGTH", 10000)
+    try:
+        terminal_length = os.getenv('ANSIBLE_VYOS_TERMINAL_LENGTH', 10000)
+        terminal_length = int(terminal_length)
+    except ValueError:
+        raise AnsibleConnectionFailure("Invalid value set for vyos terminal length '%s', value should be a valid integer string" % terminal_length)
 
     def on_open_shell(self):
         try:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/68031

Convert value to env variable ANSIBLE_VYOS_TERMINAL_LENGTH
to integer to identify if the value is valid integer string
if not raise an execption
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/vyos.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
