### PR TITLE
Move requirements to top-level directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible
+paramiko

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
-black
+black ; python_version > '3.5'
 flake8
+pexpect
 yamllint

--- a/tests/integration/network-integration.requirements.txt
+++ b/tests/integration/network-integration.requirements.txt
@@ -1,6 +1,0 @@
-pexpect # for _user test
-scp # for Cisco ios
-selectors2 # for ncclient
-ncclient # for Junos
-jxmlease # for Junos
-xmltodict # for Junos


### PR DESCRIPTION
This removes the dependency on ansible-test to manage our dependencies.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/366
Signed-off-by: Paul Belanger <pabelanger@redhat.com>